### PR TITLE
add signTransactions options

### DIFF
--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -79,6 +79,7 @@ export const verifySignature = (
 
 type ToSignTransaction = {
   txHex: string
+  unSignTx?:mvc.Transaction
   scriptHex: string
   inputIndex: number
   inputIndexes?: number[]
@@ -175,7 +176,7 @@ export const signTransactions = async (toSignTransactions: ToSignTransaction[]) 
     txid: string
   }[] = []
   for (let i = 0; i < toSignTransactionsWithDependsOn.length; i++) {
-    let { txHex, scriptHex, inputIndex, satoshis, sigtype, hasMetaId } = toSignTransactionsWithDependsOn[i]
+    let { txHex, scriptHex, inputIndex, satoshis, sigtype, hasMetaId,unSignTx } = toSignTransactionsWithDependsOn[i]
     const toSign = toSignTransactionsWithDependsOn[i]
 
     if (!sigtype) {
@@ -236,7 +237,7 @@ export const signTransactions = async (toSignTransactions: ToSignTransaction[]) 
     }
 
     // Check if the input belongs to our address before signing
-    const input = tx.inputs[inputIndex]
+    const input =unSignTx ? unSignTx.inputs[inputIndex] : tx.inputs[inputIndex]
     if (!input.output) {
       throw new Error('The output of the input must be provided')
     }


### PR DESCRIPTION
The signTransactions method, when reconstructing deserialized transactions, discards the output references in the inputs. The original transaction must be passed to the plugin wallet for proper operation